### PR TITLE
Do not write executeable config files

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -2,17 +2,20 @@ case xvfb_systype
 when 'systemd'
   path = '/etc/systemd/system/xvfb.service'
   src = 'systemd.erb'
+  mode = '0644'
 when 'upstart'
   path = '/etc/init/xvfb.conf'
   src = 'upstart.erb'
+  mode = '0644'
 else
   path = '/etc/init.d/xvfb'
   src = 'sysvinit.erb'
+  mode = '0755'
 end
 
 template path do
   source src
-  mode '0755'
+  mode mode
   variables(
     display: node['xvfb']['display'],
     screennum: node['xvfb']['screennum'],


### PR DESCRIPTION
systemd and upstart do not need executeable configuration, only sysvinit does. systemd complains about this.